### PR TITLE
Use integer handles instead of pointers for savegame textures

### DIFF
--- a/program/interface/save_load.c
+++ b/program/interface/save_load.c
@@ -683,7 +683,7 @@ void FillEmptySaveSlot(int nSlot)
 	ShowDataForSave(nSlot,"empty",0,"");
 }
 
-void ShowDataForSave(int nSlot, string picname, ptr picpointer, string strdata)
+void ShowDataForSave(int nSlot, string picname, int picpointer, string strdata)
 {
 	string nodname = "SAVEIMG" + (nSlot+1);
 	bool bClickable = bThisSave;
@@ -700,7 +700,7 @@ void ShowDataForSave(int nSlot, string picname, ptr picpointer, string strdata)
 	}
 	
 	if( picpointer ) {
-		SendMessage( &GameInterface, "lslp", MSG_INTERFACE_MSG_TO_NODE, nodname, 7, picpointer );
+		SendMessage( &GameInterface, "lsll", MSG_INTERFACE_MSG_TO_NODE, nodname, 7, picpointer );
 		bClickable = true;
 	}
 	SetSelectable( nodname, bClickable );
@@ -814,7 +814,7 @@ void LoadInfo(int nInfoIdx, int nSaveIdx, string sSaveName)
 void procLoadOneSaveInfo()
 {
 	int i;
-	ptr pTex;
+	int texture;
 	string strdata;
 	bool bYesScrShoter = IsEntity(&scrshot);
 	for( i=0; i<10; i++ )
@@ -826,12 +826,12 @@ void procLoadOneSaveInfo()
 				g_oSaveList[i].loaded = 1;
 				strdata = "";
 				if( bYesScrShoter ) {
-					pTex = SendMessage( scrshot, "lsse", MSG_SCRSHOT_READ, "SAVE\"+currentProfile, g_oSaveList[i].savefile, &strdata );
+					texture = SendMessage( scrshot, "lsse", MSG_SCRSHOT_READ, "SAVE\"+currentProfile, g_oSaveList[i].savefile, &strdata );
 				}
 				if( strdata == "" ) {
 					ShowDataForSave(i,"corrupted",0,"");
 				} else {
-					ShowDataForSave(i,"",pTex,strdata);
+					ShowDataForSave(i,"",texture,strdata);
 				}
 				if( bYesScrShoter ) {
 					SendMessage( scrshot, "ls", MSG_SCRSHOT_RELEASE, g_oSaveList[i].savefile );


### PR DESCRIPTION
Updates the code to use texture handles instead of pointers

Depends on #storm-devs/storm-engine/pull/153